### PR TITLE
Fix code to ignore all collision meshes in grippers and gripper base

### DIFF
--- a/tutorials/pick_and_place/Scripts/TrajectoryPlanner.cs
+++ b/tutorials/pick_and_place/Scripts/TrajectoryPlanner.cs
@@ -237,7 +237,19 @@ public class TrajectoryPlanner : MonoBehaviour
     void Start()
     {
         // Ignore collisions between gripper base and left/right grippers as the grippers slide along the base's edge
-        Physics.IgnoreCollision(gripperBase.GetComponentInChildren<Collider>(), rightGripperGameObject.GetComponentInChildren<Collider>());
-        Physics.IgnoreCollision(leftGripperGameObject.GetComponentInChildren<Collider>(), gripperBase.GetComponentInChildren<Collider>());
+        Collider[] gripperBaseColliders = gripperBase.GetComponentsInChildren<Collider>();
+        Collider[] rightGripperCollider = rightGripper.GetComponentsInChildren<Collider>();
+        Collider[] leftGripperCollider = leftGripper.GetComponentsInChildren<Collider>();
+        foreach(Collider gripBase in gripperBaseColliders)
+        {
+            foreach(Collider rightGrip in rightGripperCollider)
+            {
+                Physics.IgnoreCollision(gripBase, rightGrip);
+            }
+            foreach(Collider leftGrip in leftGripperCollider)
+            {
+                Physics.IgnoreCollision(leftGrip, gripBase);
+            }
+        }
     }
 }


### PR DESCRIPTION
<img width="554" alt="image" src="https://user-images.githubusercontent.com/60901103/98815053-6d178500-23db-11eb-873e-fd155faf12b2.png">
VHACD creates a convex hull with amalgam of smaller convex Mesh Colliders. Corrected the trajectory planner to ignore all the collisions of the grippers and gripper base.