### PR TITLE
Hotfix: Fixing missed dependency name change in niryo_moveit package.xml

### DIFF
--- a/tutorials/pick_and_place/ROS/src/niryo_moveit/package.xml
+++ b/tutorials/pick_and_place/ROS/src/niryo_moveit/package.xml
@@ -17,7 +17,7 @@
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>tcp_endpoint</build_depend>
+  <build_depend>ros_tcp_endpoint</build_depend>
   <build_depend>moveit_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>controller_manager</build_depend>
@@ -25,11 +25,11 @@
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
-  <build_export_depend>tcp_endpoint</build_export_depend>
+  <build_export_depend>ros_tcp_endpoint</build_export_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>tcp_endpoint</exec_depend>
+  <exec_depend>ros_tcp_endpoint</exec_depend>
 
 <!--   <run_depend>franka_description</run_depend> -->
   <exec_depend>moveit_ros_move_group</exec_depend>


### PR DESCRIPTION
I missed a rename in niryo_moveit's package.xml, causing it to fail to build. Fixed the naming and tested with a rebuild to confirm working.