### PR TITLE
convert all files with dos2unix

### DIFF
--- a/tutorials/pick_and_place/docker/Dockerfile
+++ b/tutorials/pick_and_place/docker/Dockerfile
@@ -16,6 +16,8 @@ COPY ./ROS/src/ros_tcp_endpoint $ROS_WORKSPACE/src/ros_tcp_endpoint
 COPY ./docker/set-up-workspace /setup.sh
 COPY docker/tutorial /
 
+RUN /bin/bash -c "find $ROS_WORKSPACE -type f -print0 | xargs -0 dos2unix"
+
 RUN dos2unix /tutorial && dos2unix /setup.sh && chmod +x /setup.sh && /setup.sh && rm /setup.sh
 
 ENTRYPOINT ["/tutorial"]


### PR DESCRIPTION
Fix incompatibility of DOS carriage return in docker Ubuntu.