### PR TITLE
Do not need to execute planned trajectories on real robot.

### DIFF
--- a/tutorials/pick_and_place/ROS/src/niryo_moveit/scripts/mover.py
+++ b/tutorials/pick_and_place/ROS/src/niryo_moveit/scripts/mover.py
@@ -43,7 +43,7 @@ def plan_trajectory(move_group, destination_pose, start_joint_angles):
     move_group.set_start_state(moveit_robot_state)
 
     move_group.set_pose_target(destination_pose)
-    plan = move_group.go(wait=True)
+    plan = move_group.plan()
 
     if not plan:
         exception_str = """
@@ -52,7 +52,7 @@ def plan_trajectory(move_group, destination_pose, start_joint_angles):
         """.format(destination_pose, destination_pose)
         raise Exception(exception_str)
 
-    return planCompat(move_group.plan())
+    return planCompat(plan)
 
 
 """

--- a/tutorials/pick_and_place/Scripts/TrajectoryPlanner.cs
+++ b/tutorials/pick_and_place/Scripts/TrajectoryPlanner.cs
@@ -129,7 +129,7 @@ public class TrajectoryPlanner : MonoBehaviour
 
     void TrajectoryResponse(MoverServiceResponse response)
     {
-        if (response.trajectories != null)
+        if (response.trajectories.Length > 0)
         {
             Debug.Log("Trajectory returned.");
             StartCoroutine(ExecuteTrajectories(response));


### PR DESCRIPTION
https://jira.unity3d.com/browse/AIRO-370

The `No data available on network stream after 10 attempts.` error is being thrown because mover is taking too long to return the trajectories to be executed. If either the time between attempts or number of attempts is increased the error goes away. 

That being said, why would such a simple trajectory take so long?

`move_group.go()` attempts to execute the planned trajectory on a physical robot which is causing most of the overhead. `move_group.plan()` is really all we need.

 I also noticed that the TCP Connector instantiates the service's response message so the trajectories would never be null.