### PR TITLE
Main branch instructions and package tags

### DIFF
--- a/tutorials/pick_and_place/0_ros_setup.md
+++ b/tutorials/pick_and_place/0_ros_setup.md
@@ -14,7 +14,7 @@ This part provides two options for setting up your ROS workspace: using Docker, 
 If you have not already cloned this project to your local machine, do so now:
 
 ```bash
-git clone --recurse-submodules https://github.com/Unity-Technologies/Unity-Robotics-Hub.git
+git clone --recurse-submodules -b main https://github.com/Unity-Technologies/Unity-Robotics-Hub.git
 ```
 
 ## Option A: Use Docker

--- a/tutorials/pick_and_place/1_urdf.md
+++ b/tutorials/pick_and_place/1_urdf.md
@@ -17,7 +17,7 @@ This part includes downloading and installing the Unity Editor, setting up a bas
 1. If you have not already cloned this project to your local machine, do so now:
 
     ```bash
-    git clone --recurse-submodules https://github.com/Unity-Technologies/Unity-Robotics-Hub.git
+    git clone --recurse-submodules -b main https://github.com/Unity-Technologies/Unity-Robotics-Hub.git
     ```
 
 1. Install [Unity Hub](https://unity3d.com/get-unity/download).

--- a/tutorials/pick_and_place/README.md
+++ b/tutorials/pick_and_place/README.md
@@ -21,7 +21,7 @@ This tutorial is designed such that you do not need prior experience with Unity 
 
 This repository provides project files for the pick-and-place tutorial, including Unity assets, URDF files, and ROS scripts. Clone this repository to a location on your local machine:
   ```bash
-  git clone --recurse-submodules https://github.com/Unity-Technologies/Unity-Robotics-Hub.git
+  git clone --recurse-submodules -b main https://github.com/Unity-Technologies/Unity-Robotics-Hub.git
   ```
 
 ## [Part 0: ROS Setup](0_ros_setup.md)

--- a/tutorials/pick_and_place/quick_demo.md
+++ b/tutorials/pick_and_place/quick_demo.md
@@ -11,7 +11,7 @@ This part uses scripts to automatically set up and run the Niryo One pick-and-pl
 
 1. Clone this repo to a location on your local machine:
     ```bash
-    git clone --recurse-submodules https://github.com/Unity-Technologies/Unity-Robotics-Hub.git
+    git clone --recurse-submodules -b main https://github.com/Unity-Technologies/Unity-Robotics-Hub.git
     ```
 
 1. Install [Docker Engine](https://docs.docker.com/engine/install/)

--- a/tutorials/quick_setup.md
+++ b/tutorials/quick_setup.md
@@ -11,9 +11,9 @@ This page provides brief instructions on installing the Unity Robotics packages.
 
     ![](../images/packman.png)
 
-1. Enter the git URL for the desired package. 
-   1. For the [ROS-TCP-Connector](https://github.com/Unity-Technologies/ROS-TCP-Connector), enter `https://github.com/Unity-Technologies/ROS-TCP-Connector.git`. 
-   1. For the [URDF-Importer](https://github.com/Unity-Technologies/URDF-Importer), enter `https://github.com/Unity-Technologies/URDF-Importer.git`. 
+1. Enter the git URL for the desired package with the latest version tag (currently v0.1.2). 
+   1. For the [ROS-TCP-Connector](https://github.com/Unity-Technologies/ROS-TCP-Connector), enter `https://github.com/Unity-Technologies/ROS-TCP-Connector.git#v0.1.2`. 
+   1. For the [URDF-Importer](https://github.com/Unity-Technologies/URDF-Importer), enter `https://github.com/Unity-Technologies/URDF-Importer.git#v0.1.2`. 
 
 1. Click `Add`. 
 

--- a/tutorials/ros_unity_integration/setup.md
+++ b/tutorials/ros_unity_integration/setup.md
@@ -56,7 +56,7 @@ Once ROS Core has started, it will print `started core service [/rosout]` to the
 
 ## Unity Scene
 1. Launch Unity and create a new scene.
-2. Open Package Manager and click the + button at the top left corner. Select "add package from git URL" and enter "https://github.com/Unity-Technologies/ROS-TCP-Connector.git" to install the [ROS TCP Connector](https://github.com/Unity-Technologies/ROS-TCP-Connector) package.
+2. Open Package Manager and click the + button at the top left corner. Select "add package from git URL" and enter `https://github.com/Unity-Technologies/ROS-TCP-Connector.git#v0.1.2` to install the latest stable release of the [ROS TCP Connector](https://github.com/Unity-Technologies/ROS-TCP-Connector) package.
 
 ![](images/add_package.png)
 


### PR DESCRIPTION
- Adding `-b main` to instruct users to checkout the main branch when cloning instead of the default dev
- Adding instruction to add package via latest stable tag (will need to be updated each version update)