### PR TITLE
Adding Editor version to Ros Integration Readme

### DIFF
--- a/tutorials/ros_unity_integration/README.md
+++ b/tutorials/ros_unity_integration/README.md
@@ -1,5 +1,8 @@
 # ROS–Unity Integration
 
+## Editor Version
+Most of our projects are developed/tested on Unity Editor version 2020.2.0f9 or later. We expect that anything 2020.2+ should be compatible, and will be actively working to ensure this for future versions. 2020.1.X and below are unlikely to work well, if at all, and we strongly encourage updating to a more recent version to support the bleeding edge updates to Unity's physics and simulation components that we are leveraging.
+
 ## ROS–Unity Communication
 ![](images/unity_ros.png)
 


### PR DESCRIPTION
Addresses user issue #179. Someone encountered missing built-in interfaces when attempting to integrate our package with an older version of the Unity Editor, which we never recommended they not do.  Adding recommendation to readme to prevent future confusion.