### PR TITLE
Updating package dependencies to proper versions

### DIFF
--- a/tutorials/pick_and_place/PickAndPlaceProject/Packages/manifest.json
+++ b/tutorials/pick_and_place/PickAndPlaceProject/Packages/manifest.json
@@ -4,7 +4,8 @@
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.3",
     "com.unity.ide.vscode": "1.2.2",
-    "com.unity.robotics.ros-tcp-connector": "https://github.com/Unity-Technologies/ROS-TCP-Connector.git?path=/com.unity.robotics.ros-tcp-connector#v0.2.0",
+    "com.unity.robotics.ros-tcp-connector":
+    "https://github.com/Unity-Technologies/ROS-TCP-Connector.git?path=/com.unity.robotics.ros-tcp-connector#dev",
     "com.unity.robotics.urdf-importer": "https://github.com/Unity-Technologies/URDF-Importer.git?path=/com.unity.robotics.urdf-importer#v0.2.0",
     "com.unity.test-framework": "1.1.18",
     "com.unity.textmeshpro": "3.0.1",


### PR DESCRIPTION
Pick and place tutorial was failing to compile its scripts because
the package manifest was pointing to an older version of
ROS-TCP-Connector.  Updated the manifest and also pulled latest changes
for ros_tcp_endpoint.

Tested by running DemoScene