### PR TITLE
Removing old version tags from git URLs in quick_setup

### DIFF
--- a/tutorials/quick_setup.md
+++ b/tutorials/quick_setup.md
@@ -11,9 +11,9 @@ This page provides brief instructions on installing the Unity Robotics packages.
 
     ![](../images/packman.png)
 
-1. Enter the git URL for the desired package. 
-   1. For the [ROS-TCP-Connector](https://github.com/Unity-Technologies/ROS-TCP-Connector), enter `https://github.com/Unity-Technologies/ROS-TCP-Connector.git?path=/com.unity.robotics.ros-tcp-connector#v0.2.0`.
-   1. For the [URDF-Importer](https://github.com/Unity-Technologies/URDF-Importer), enter `https://github.com/Unity-Technologies/URDF-Importer.git?path=/com.unity.robotics.urdf-importer#v0.2.0`.
+1. Enter the git URL for the desired package. Note: you can append a version tag to the end of the git url, like `#v0.2.0` or `#v0.3.0`, to declare a specific package version, or exclude the tag to get the latest from the package's `main` branch.
+   1. For the [ROS-TCP-Connector](https://github.com/Unity-Technologies/ROS-TCP-Connector), enter `https://github.com/Unity-Technologies/ROS-TCP-Connector.git?path=/com.unity.robotics.ros-tcp-connector`.
+   1. For the [URDF-Importer](https://github.com/Unity-Technologies/URDF-Importer), enter `https://github.com/Unity-Technologies/URDF-Importer.git?path=/com.unity.robotics.urdf-importer`.
 
 1. Click `Add`. 
 


### PR DESCRIPTION
## Proposed change(s)

Addressing user issue #209. Our quick_setup guide was still recommending users check out v.0.2.0 of our packages. Removed the reference to a specific package version and instead included a note that users can explicitly declare a package version if desired.

### Types of change(s)

- [x] Documentation update

## Testing and Verification

Tested by making the change locally in the package manifest.

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Updated the documentation as appropriate
