### PR TITLE
added chmod +x to Dockerfile to ensure the python scripts are executable

### DIFF
--- a/tutorials/pick_and_place/docker/Dockerfile
+++ b/tutorials/pick_and_place/docker/Dockerfile
@@ -22,4 +22,8 @@ RUN dos2unix /tutorial && dos2unix /setup.sh && chmod +x /setup.sh && /setup.sh 
 
 WORKDIR $ROS_WORKSPACE
 
+# making sure the file modes are executable
+RUN chmod +x src/niryo_moveit/scripts/*.py
+
 ENTRYPOINT ["/tutorial"]
+


### PR DESCRIPTION
## Proposed change(s) 

Added `chmod +x` to make sure all python scripts in `niryo_moveit` are executable after a docker image is built.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

- built the docker image:
  ```
  cd tutorials/pick_and_place$
  docker build -t unity-robotics:pick-and-place -f docker/Dockerfile .
  ```
- started the docker image:
   ```
   docker run -it --rm -p 10000:10000 -p 5005:5005 unity-robotics:pick-and-place /bin/bash
  ```
- checked that all scripts are executable:
   ```
   ls -al src/niryo_moveit/scripts/
   ```
- confirmed the ROS scripts are executing:
  ```
  roslaunch niryo_moveit part_2.launch
  roslaunch niryo_moveit part_3.launch
  ```
- Also performed a negative test in which replaced `chmod +x` to `chmod -x` in the Docker file, and verified that scripts become not executable and both run scripts don't run due to wrong file permissions.



### Test Configuration:
- Unity Version: 2021.1.7f1
- Unity machine OS + version: macOS Catalina: 10.15.7
- ROS machine OS + version: Ubuntu 18.04, ROS Melodic on Docker
- ROS–Unity communication: Docker

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the documentation as appropriate

## Other comments