### PR TITLE
Fix dockerfile public key

### DIFF
--- a/tutorials/pick_and_place/docker/Dockerfile
+++ b/tutorials/pick_and_place/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM ros:melodic-ros-base
 
+RUN sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654
+
 RUN sudo apt-get update && sudo apt-get install -y vim iputils-ping net-tools python-pip ros-melodic-robot-state-publisher ros-melodic-moveit ros-melodic-rosbridge-suite ros-melodic-joy ros-melodic-ros-control ros-melodic-ros-controllers ros-melodic-tf2-web-republisher dos2unix
 
 RUN sudo -H pip install rospkg jsonpickle


### PR DESCRIPTION
## Proposed change(s)

Add fetching the public key from ubuntu keyserver

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Tested by rebuilding the docker image 
```
docker builder prune
docker build -t unity-robotics:pick-and-place -f docker/Dockerfile .
```

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [ ] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments
