### PR TITLE
AIRO-687 Update ROS topic to SourceDestination_input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 
+Changed the Pick and Place Demo's topic from SourceDestination to SourceDestination_input
+
 ### Deprecated
 
 ### Removed

--- a/tutorials/pick_and_place/ROS/src/niryo_moveit/scripts/server_endpoint.py
+++ b/tutorials/pick_and_place/ROS/src/niryo_moveit/scripts/server_endpoint.py
@@ -15,7 +15,7 @@ def main():
 
     # Start the Server Endpoint with a ROS communication objects dictionary for routing messages
     tcp_server.start({
-        'SourceDestination_input': RosPublisher('SourceDestination', NiryoMoveitJoints, queue_size=10),
+        'SourceDestination_input': RosPublisher('SourceDestination_input', NiryoMoveitJoints, queue_size=10),
         'NiryoTrajectory': RosSubscriber('NiryoTrajectory', NiryoTrajectory, tcp_server),
         'niryo_moveit': RosService('niryo_moveit', MoverService),
         'niryo_one/commander/robot_action/goal': RosSubscriber('niryo_one/commander/robot_action/goal', RobotMoveActionGoal, tcp_server),


### PR DESCRIPTION
## Proposed change(s)

Update the ROS Topic to SourceDestination_input in the Pick and Place Demo. This is to make the `rostopic list` and validation message returns the same topic name. 

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Original discussion in:
https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/224#issuecomment-852819479
https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/224#issuecomment-853316725 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Tested with the pick and place quick demo. On ROS side, I verified that `rostopic list` returns `SourceDestination_input` instead of `SourceDestination`
![Screen Shot 2021-06-08 at 10 49 00 AM](https://user-images.githubusercontent.com/1437228/121233239-4ae9c680-c847-11eb-848d-a5998110c8fa.png)


### Test Configuration:
- Unity Version: Unity 2020.2.4f1
- Unity machine OS + version: macOs BigSur
- ROS machine OS + version: ROS melodic
- ROS–Unity communication:  Docker

## Checklist
- [X] Ensured this PR is up-to-date with the `dev` branch
- [X] Created this PR to target the `dev` branch
- [X] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/CONTRIBUTING.md)
- [X] Added tests that prove my fix is effective or that my feature works - Manual test
- [X] Updated the [Changelog](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md#unreleased)
- [X] Updated the documentation as appropriate

## Other comments
