### PR TITLE
add compatible version to the tutorial

### DIFF
--- a/tutorials/pick_and_place/1_urdf.md
+++ b/tutorials/pick_and_place/1_urdf.md
@@ -22,7 +22,12 @@ This part includes downloading and installing the Unity Editor, setting up a bas
 
 1. Install [Unity Hub](https://unity3d.com/get-unity/download).
 
-1. Go it the "Installs" tab in the Unity Hub, and click the "Add" button. Select Unity **2020.3.11f1 (LTS)**. If this version is no longer available through the hub, you can find it in the [Unity Download Archive](https://unity3d.com/get-unity/download/archive).
+1. Go it the "Installs" tab in the Unity Hub, and click the "Add" button. Select Unity **2020.3.11f1 (LTS)**. If this version is no longer available through the hub, you can find it in the [Unity Download Archive](https://unity3d.com/get-unity/download/archive). 
+   > Note: If you want to use another Unity version, the following versions work for the Pick-and-Place tutorial:
+
+   > - Unity 2020.3: 2020.3.10f1 or later
+   > - Unity 2021.1: 2021.1.8f1 or later
+   > - Unity 2021.2: 2021.2.a16 or later
 
 1. Go to the "Projects" tab in the Unity Hub, click the "Add" button, and navigate to and select the PickAndPlaceProject directory within this cloned repository (`/PATH/TO/Unity-Robotics-Hub/tutorials/pick_and_place/PickAndPlaceProject/`) to add the tutorial project to your Hub.
 


### PR DESCRIPTION
## Proposed change(s)

Elaborate on the compatible Unity versions for the pick and place tutorial (AIRO-742)

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [x] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [ ] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md#unreleased)
- [x] Updated the documentation as appropriate

## Other comments
