### PR TITLE
Updating current angle update functions to use jointPositions rather …

### DIFF
--- a/tutorials/pick_and_place/Scripts/SourceDestinationPublisher.cs
+++ b/tutorials/pick_and_place/Scripts/SourceDestinationPublisher.cs
@@ -2,6 +2,7 @@ using RosMessageTypes.NiryoMoveit;
 using UnityEngine;
 using Unity.Robotics.ROSTCPConnector;
 using Unity.Robotics.ROSTCPConnector.ROSGeometry;
+using Unity.Robotics.UrdfImporter;
 using RosMessageTypes.Geometry;
 
 public class SourceDestinationPublisher : MonoBehaviour
@@ -19,8 +20,8 @@ public class SourceDestinationPublisher : MonoBehaviour
     private int numRobotJoints = 6;
     private readonly Quaternion pickOrientation = Quaternion.Euler(90, 90, 0);
 
-    // Articulation Bodies
-    private ArticulationBody[] jointArticulationBodies;
+    // Robot Joints
+    private UrdfJointRevolute[] revoluteJoints;
 
     /// <summary>
     /// 
@@ -30,36 +31,36 @@ public class SourceDestinationPublisher : MonoBehaviour
         // Get ROS connection static instance
         ros = ROSConnection.instance;
 
-        jointArticulationBodies = new ArticulationBody[numRobotJoints];
+        revoluteJoints = new UrdfJointRevolute[numRobotJoints];
         string shoulder_link = "world/base_link/shoulder_link";
-        jointArticulationBodies[0] = niryoOne.transform.Find(shoulder_link).GetComponent<ArticulationBody>();
+        revoluteJoints[0] = niryoOne.transform.Find(shoulder_link).GetComponent<UrdfJointRevolute>();
 
         string arm_link = shoulder_link + "/arm_link";
-        jointArticulationBodies[1] = niryoOne.transform.Find(arm_link).GetComponent<ArticulationBody>();
+        revoluteJoints[1] = niryoOne.transform.Find(arm_link).GetComponent<UrdfJointRevolute>();
 
         string elbow_link = arm_link + "/elbow_link";
-        jointArticulationBodies[2] = niryoOne.transform.Find(elbow_link).GetComponent<ArticulationBody>();
+        revoluteJoints[2] = niryoOne.transform.Find(elbow_link).GetComponent<UrdfJointRevolute>();
 
         string forearm_link = elbow_link + "/forearm_link";
-        jointArticulationBodies[3] = niryoOne.transform.Find(forearm_link).GetComponent<ArticulationBody>();
+        revoluteJoints[3] = niryoOne.transform.Find(forearm_link).GetComponent<UrdfJointRevolute>();
 
         string wrist_link = forearm_link + "/wrist_link";
-        jointArticulationBodies[4] = niryoOne.transform.Find(wrist_link).GetComponent<ArticulationBody>();
+        revoluteJoints[4] = niryoOne.transform.Find(wrist_link).GetComponent<UrdfJointRevolute>();
 
         string hand_link = wrist_link + "/hand_link";
-        jointArticulationBodies[5] = niryoOne.transform.Find(hand_link).GetComponent<ArticulationBody>();
+        revoluteJoints[5] = niryoOne.transform.Find(hand_link).GetComponent<UrdfJointRevolute>();
     }
 
     public void Publish()
     {
         NiryoMoveitJointsMsg sourceDestinationMessage = new NiryoMoveitJointsMsg();
 
-        sourceDestinationMessage.joint_00 = jointArticulationBodies[0].jointPositions[0] * Mathf.Rad2Deg;
-        sourceDestinationMessage.joint_01 = jointArticulationBodies[1].jointPositions[0] * Mathf.Rad2Deg;
-        sourceDestinationMessage.joint_02 = jointArticulationBodies[2].jointPositions[0] * Mathf.Rad2Deg;
-        sourceDestinationMessage.joint_03 = jointArticulationBodies[3].jointPositions[0] * Mathf.Rad2Deg;
-        sourceDestinationMessage.joint_04 = jointArticulationBodies[4].jointPositions[0] * Mathf.Rad2Deg;
-        sourceDestinationMessage.joint_05 = jointArticulationBodies[5].jointPositions[0] * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_00 = revoluteJoints[0].GetPosition() * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_01 = revoluteJoints[1].GetPosition() * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_02 = revoluteJoints[2].GetPosition() * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_03 = revoluteJoints[3].GetPosition() * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_04 = revoluteJoints[4].GetPosition() * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_05 = revoluteJoints[5].GetPosition() * Mathf.Rad2Deg;
 
         // Pick Pose
         sourceDestinationMessage.pick_pose = new PoseMsg

--- a/tutorials/pick_and_place/Scripts/SourceDestinationPublisher.cs
+++ b/tutorials/pick_and_place/Scripts/SourceDestinationPublisher.cs
@@ -54,12 +54,12 @@ public class SourceDestinationPublisher : MonoBehaviour
     {
         NiryoMoveitJointsMsg sourceDestinationMessage = new NiryoMoveitJointsMsg();
 
-        sourceDestinationMessage.joint_00 = jointArticulationBodies[0].xDrive.target;
-        sourceDestinationMessage.joint_01 = jointArticulationBodies[1].xDrive.target;
-        sourceDestinationMessage.joint_02 = jointArticulationBodies[2].xDrive.target;
-        sourceDestinationMessage.joint_03 = jointArticulationBodies[3].xDrive.target;
-        sourceDestinationMessage.joint_04 = jointArticulationBodies[4].xDrive.target;
-        sourceDestinationMessage.joint_05 = jointArticulationBodies[5].xDrive.target;
+        sourceDestinationMessage.joint_00 = jointArticulationBodies[0].jointPositions[0] * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_01 = jointArticulationBodies[1].jointPositions[0] * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_02 = jointArticulationBodies[2].jointPositions[0] * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_03 = jointArticulationBodies[3].jointPositions[0] * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_04 = jointArticulationBodies[4].jointPositions[0] * Mathf.Rad2Deg;
+        sourceDestinationMessage.joint_05 = jointArticulationBodies[5].jointPositions[0] * Mathf.Rad2Deg;
 
         // Pick Pose
         sourceDestinationMessage.pick_pose = new PoseMsg

--- a/tutorials/pick_and_place/Scripts/TrajectoryPlanner.cs
+++ b/tutorials/pick_and_place/Scripts/TrajectoryPlanner.cs
@@ -82,12 +82,12 @@ public class TrajectoryPlanner : MonoBehaviour
     {
         NiryoMoveitJointsMsg joints = new NiryoMoveitJointsMsg();
 
-        joints.joint_00 = jointArticulationBodies[0].jointPositions[0] * Mathf.Rad2Deg;
-        joints.joint_01 = jointArticulationBodies[1].jointPositions[0] * Mathf.Rad2Deg;
-        joints.joint_02 = jointArticulationBodies[2].jointPositions[0] * Mathf.Rad2Deg;
-        joints.joint_03 = jointArticulationBodies[3].jointPositions[0] * Mathf.Rad2Deg;
-        joints.joint_04 = jointArticulationBodies[4].jointPositions[0] * Mathf.Rad2Deg;
-        joints.joint_05 = jointArticulationBodies[5].jointPositions[0] * Mathf.Rad2Deg;
+        joints.joint_00 = jointArticulationBodies[0].jointPosition[0] * Mathf.Rad2Deg;
+        joints.joint_01 = jointArticulationBodies[1].jointPosition[0] * Mathf.Rad2Deg;
+        joints.joint_02 = jointArticulationBodies[2].jointPosition[0] * Mathf.Rad2Deg;
+        joints.joint_03 = jointArticulationBodies[3].jointPosition[0] * Mathf.Rad2Deg;
+        joints.joint_04 = jointArticulationBodies[4].jointPosition[0] * Mathf.Rad2Deg;
+        joints.joint_05 = jointArticulationBodies[5].jointPosition[0] * Mathf.Rad2Deg;
 
         return joints;
     }

--- a/tutorials/pick_and_place/Scripts/TrajectoryPlanner.cs
+++ b/tutorials/pick_and_place/Scripts/TrajectoryPlanner.cs
@@ -82,12 +82,12 @@ public class TrajectoryPlanner : MonoBehaviour
     {
         NiryoMoveitJointsMsg joints = new NiryoMoveitJointsMsg();
 
-        joints.joint_00 = jointArticulationBodies[0].xDrive.target;
-        joints.joint_01 = jointArticulationBodies[1].xDrive.target;
-        joints.joint_02 = jointArticulationBodies[2].xDrive.target;
-        joints.joint_03 = jointArticulationBodies[3].xDrive.target;
-        joints.joint_04 = jointArticulationBodies[4].xDrive.target;
-        joints.joint_05 = jointArticulationBodies[5].xDrive.target;
+        joints.joint_00 = jointArticulationBodies[0].jointPositions[0] * Mathf.Rad2Deg;
+        joints.joint_01 = jointArticulationBodies[1].jointPositions[0] * Mathf.Rad2Deg;
+        joints.joint_02 = jointArticulationBodies[2].jointPositions[0] * Mathf.Rad2Deg;
+        joints.joint_03 = jointArticulationBodies[3].jointPositions[0] * Mathf.Rad2Deg;
+        joints.joint_04 = jointArticulationBodies[4].jointPositions[0] * Mathf.Rad2Deg;
+        joints.joint_05 = jointArticulationBodies[5].jointPositions[0] * Mathf.Rad2Deg;
 
         return joints;
     }


### PR DESCRIPTION
…than xDrive.Target

## Proposed change(s)
Using ArticulationBody jointPositions, rather than the xDrive.target, for updating the current joint angle positions.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

I made an issue [here](https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/263).

### Types of change(s)

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification
Replaced the tutorial scripts with the changes included in this PR and ran through the entire tutorial exercise for the pick and place task. It worked as expected.

### Test Configuration:
- Unity Version: Unity 2020.3.10f1
- Unity machine OS + version: Ubuntu 20.04
- ROS machine OS + version: Ubuntu 20.04, ROS Noetic]
- ROS–Unity communication: local TCP/IP connection

## Checklist
- [X] Ensured this PR is up-to-date with the `dev` branch
- [X] Created this PR to target the `dev` branch
- [X] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/CONTRIBUTING.md)
- [X] Added tests that prove my fix is effective or that my feature works (not sure if more testing is required?)
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments
