### PR TITLE
Remove ROS2 Beta Mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Here’s a peek into what our Physics Team is hard at work on…
 - **Query primitives**. These simple, GameObject-less shapes allow for collision detection without requiring simulation (i.e., without calling Physics.Simulate). This feature will allow users to initialize objects in feasible locations, and can also be used for motion planning.
 
 ## [**New!**] ROS 2
-Interested in early access to ROS 2 integration? Email [unity-robotics@unity3d.com](mailto:unity-robotics@unity3d.com) to join our alpha program.
+ROS2 support is now available! You can get started by following [this tutorial](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/tutorials/ros_unity_integration/publisher.md).
+
 
 ## FAQs
 [FAQs](faq.md)

--- a/faq.md
+++ b/faq.md
@@ -13,9 +13,9 @@
 - [Can't find what you're looking for?](#cant-find-what-youre-looking-for)
 
 # General Questions
-Is ROS 2 support planned?
+Does the package support ROS 2?
 ---
-We definitely plan to support ROS 2 in the future. Let us know more about your use case in order to prioritize our work by reaching out to us at [unity-robotics@unity3d.com](mailto:unity-robotics@unity3d.com).
+Yes it does! You can get started by following [this tutorial](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/tutorials/ros_unity_integration/publisher.md).
 
 How does your Unity integration compare to ROS#?
 ---
@@ -23,7 +23,7 @@ Two of the Unity Robotics repos (URDF Importer and TCP Connector) have been fork
 
 In the URDF Importer we have added the functionality to instantiate a robot from URDF into a Unity scene with [Articulation Body](https://docs.unity3d.com/2020.2/Documentation/Manual/class-ArticulationBody.html) components on their corresponding joints.
 
-Aside from facilitating communication with the TCP Endpoint, the TCP Connector contains the `MessageGeneration` code from ROS#. We added the extra functionality that when generating a C# class from a ROS message, functions are also generated that will serialize and deserialize the messages as ROS would internally.
+Aside from facilitating communication with the TCP Endpoint, the TCP Connector contains an adapted version of the `MessageGeneration` code from ROS#. However, unlike ROS# our messages are transmitted in ROS's own serialization format, eliminating the JSON encoding/decoding step for some significant performance improvements.
 
 You can find more details about the differences between our implementation and ROS#, along with some of their future plans, in the [ROS# project](https://github.com/siemens/ros-sharp/wiki/Ext_RosSharp_RoboticsHub#differences-between-unity-robotics-hub-and-ros).
 

--- a/tutorials/pick_and_place/0_ros_setup.md
+++ b/tutorials/pick_and_place/0_ros_setup.md
@@ -92,6 +92,8 @@ The ROS workspace is now ready to accept commands!
     ROS_IP: 192.168.50.149
     ```
 
+1. (Optional) By default, the server_endpoint will listen on port 10000, but this is also controlled by a parameter. If you need to change it, you can run the command `rosparam set ROS_TCP_PORT 10000`, replacing 10000 with the desired port number.
+
 The ROS workspace is now ready to accept commands!
 
 ---


### PR DESCRIPTION
Remove mentions of ROS2 beta from docs, since the beta has ended and ROS2 integration is live.