### PR TITLE
AIRO-1210 Fix dotnet format

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -15,5 +15,6 @@ jobs:
                   python-version: 3.7.x
             - uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: '3.1.x'
+                  dotnet-version: '6.0.x'
+                  include-prerelease: true
             - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,8 @@ repos:
 
 
     - repo: https://github.com/dotnet/format
-      rev: "7e343070a0355c86f72bdee226b5e19ffcbac931"
+      rev: v5.1.225507
       hooks:
           - id: dotnet-format
+            entry: dotnet-format whitespace
             args: [--folder, --include]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Add the [Close Stale Issues](https://github.com/marketplace/actions/close-stale-
 
 ### Fixed
 
+Fixed dotnet format
+
 ## v0.5.1
 
 ### Changed


### PR DESCRIPTION
## Proposed change(s)
We are following ml-agent's fix in [PR](https://github.com/Unity-Technologies/ml-agents/pull/5528/files) 
"Pre-commit is using a version of dotnet and dotnet-format and has picked up a newer version of the utility that is not compatible with .NET 3.1 or 5.x -- it installs it's packages using dotnet tool install. This version's default entrypoint is also incompatible with our project structure, as the style and analyzer subcommands are now run by default and do not support the --folder option.

The entrypoint can be over-ridden to specify the whitespace module, which should match previous behavior."

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Fix in [PR](https://github.com/Unity-Technologies/ml-agents/pull/5528/files)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Tested with github workflow pre-commit

### Test Configuration:
- Unity Version: [e.g. Unity 2020.2.0f1]
- Unity machine OS + version: [e.g. Windows 10]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]
- ROS–Unity communication: [e.g. Docker]

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/CONTRIBUTING.md)
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md#unreleased)
- [x] Updated the documentation as appropriate

## Other comments
