### PR TITLE
AIRO-620 Updating link to endpoint ros2 branch

### DIFF
--- a/tutorials/ros_unity_integration/setup.md
+++ b/tutorials/ros_unity_integration/setup.md
@@ -71,7 +71,7 @@ Follow these steps if using ROS2:
 
    This should build a docker image and start it.
 
-   b) Alternatively, if you're not going to use the Docker image, download the [ROS2 branch of the ROS-TCP-Endpoint](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/tree/ROS2) repository and copy it into the `src` folder in your Colcon workspace. Then navigate to your Colcon workspace and run the following commands:
+   b) Alternatively, if you're not going to use the Docker image, download the [ROS2 branch of the ROS-TCP-Endpoint](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/tree/main-ros2) repository and copy it into the `src` folder in your Colcon workspace. Then navigate to your Colcon workspace and run the following commands:
 
     ```bash
 	source install/setup.bash


### PR DESCRIPTION
## Proposed change(s)

As part of the changes to support testing all our dev and main branches, I renamed the endpoint's ROS2 branch to main-ros2.  This change updates the link here.
