### PR TITLE
Modifying Pick and Place pt. 4 to treat services like services

### DIFF
--- a/tutorials/pick_and_place/PickAndPlaceProject/Assets/RosMessages.meta
+++ b/tutorials/pick_and_place/PickAndPlaceProject/Assets/RosMessages.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7e9ac35ae6089214eb6d10352af3bc26
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/tutorials/pick_and_place/Scripts_Part4/RealSimPickAndPlace.cs
+++ b/tutorials/pick_and_place/Scripts_Part4/RealSimPickAndPlace.cs
@@ -71,8 +71,10 @@ public class RealSimPickAndPlace : MonoBehaviour
         // Get ROS connection static instance
         m_Ros = ROSConnection.GetOrCreateInstance();
         m_Ros.Subscribe<RobotMoveActionGoal>(rosRobotCommandsTopicName, ExecuteRobotCommands);
+        m_Ros.RegisterRosService<MoverServiceRequest, MoverServiceResponse>(rosJointPublishTopicName);
     }
 
+  
     /// <summary>
     ///     Close the gripper
     /// </summary>
@@ -133,7 +135,7 @@ public class RealSimPickAndPlace : MonoBehaviour
             request.joints_input.joints[i] = m_JointArticulationBodies[i].jointPosition[0];
         }
 
-        m_Ros.Publish(rosJointPublishTopicName, request);
+        m_Ros.SendServiceMessage<MoverServiceResponse>(rosJointPublishTopicName, request);
     }
 
     /// <summary>


### PR DESCRIPTION
## Proposed change(s)

Part 4 of Pick and Place was publishing messages over a service topic using a standard ROS Publisher rather than our API for Services. It also seems to be broken in general due to actions not registering to the message registry. Modified project on both Unity and ROS side to use the Service API for service messages, and added some quality of life updates to the ROS node so starting it without an accompanying Niryo One param server doesn't lock up a user's terminal.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Addresses issue #333 and [this forum post](https://forum.unity.com/threads/followjointtrajectory-action-does-not-generate-register-code.1201636/).

### Types of change(s)

- [x] Bug fix

## Testing and Verification

Ran nodes up to the point where they fail to connect to a Niryo One, which I don't have on hand.

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md#unreleased)
- [x] Updated the documentation as appropriate

## Other comments
