### PR TITLE
AIRO-1617 Private ros params

### DIFF
--- a/tutorials/pick_and_place/0_ros_setup.md
+++ b/tutorials/pick_and_place/0_ros_setup.md
@@ -74,26 +74,6 @@ The ROS workspace is now ready to accept commands!
 
 1. If you have not already built and sourced the ROS workspace since importing the new ROS packages, navigate to your ROS workplace, and run `catkin_make && source devel/setup.bash`. Ensure there are no errors.
 
-1. The ROS parameters will need to be set to your configuration in order to allow the server endpoint to fetch values for the TCP connection, stored in `src/niryo_moveit/config/params.yaml`. From your ROS workspace, assign the ROS IP in this `yaml` file:
-
-    ```bash
-    echo "ROS_IP: $(hostname -I)" > src/niryo_moveit/config/params.yaml
-    ```
-
-    > Note: You can also manually assign this value by navigating to the `params.yaml` file and opening it for editing.
-
-    ```yaml
-    ROS_IP: <your ROS IP>
-    ```
-
-    e.g.
-
-    ```yaml
-    ROS_IP: 192.168.50.149
-    ```
-
-1. (Optional) By default, the server_endpoint will listen on port 10000, but this is also controlled by a parameter. If you need to change it, you can run the command `rosparam set ROS_TCP_PORT 10000`, replacing 10000 with the desired port number.
-
 The ROS workspace is now ready to accept commands!
 
 ---
@@ -102,8 +82,6 @@ The ROS workspace is now ready to accept commands!
 - Building the Docker image may throw an `Could not find a package configuration file provided by...` exception if one or more of the directories in ROS/ appears empty. Try downloading the submodules again via `git submodule update --init --recursive`.
 
 - `...failed because unknown error handler name 'rosmsg'` This is due to a bug in an outdated package version. Try running `sudo apt-get update && sudo apt-get upgrade` to upgrade packages.
-
-- If the ROS TCP handshake fails (e.g. `ROS-Unity server listening...` printed on the Unity side but no `ROS-Unity Handshake received` on the ROS side), the ROS IP may not have been set correctly in the params.yaml file. Try running `echo "ROS_IP: $(hostname -I)" > src/niryo_moveit/config/params.yaml` in a terminal from your ROS workspace.
 
 ---
 

--- a/tutorials/pick_and_place/2_ros_tcp.md
+++ b/tutorials/pick_and_place/2_ros_tcp.md
@@ -174,14 +174,25 @@ Most of the ROS setup has been provided via the `niryo_moveit` package. This sec
 
    > Note: Running `roslaunch` automatically starts [ROS Core](http://wiki.ros.org/roscore) if it is not already running.
 
-   > Note: This launch file has been copied below for reference. The server_endpoint and trajectory_subscriber nodes are launched from this file, and the ROS params (set up in [Part 0](0_ros_setup.md)) are loaded from this command. The launch files for this project are available in the package's `launch` directory, i.e. `src/niryo_moveit/launch/`.
+   > Note: This launch file has been copied below for reference. The server_endpoint and trajectory_subscriber nodes are launched from this file. The launch files for this project are available in the package's `launch` directory, i.e. `src/niryo_moveit/launch/`.
 
    ```xml
-   <launch>
-      <rosparam file="$(find niryo_moveit)/config/params.yaml" command="load"/>
-      <node name="server_endpoint" pkg="niryo_moveit" type="server_endpoint.py" args="--wait" output="screen" respawn="true" />
-      <node name="trajectory_subscriber" pkg="niryo_moveit" type="trajectory_subscriber.py" args="--wait" output="screen"/>
-   </launch>
+	<launch>
+		<arg name="tcp_ip" default="0.0.0.0"/>
+		<arg name="tcp_port" default="10000"/>
+
+		<node name="server_endpoint" pkg="ros_tcp_endpoint" type="default_server_endpoint.py" args="--wait" output="screen" respawn="true">
+			<param name="tcp_ip" type="string" value="$(arg tcp_ip)"/>
+			<param name="tcp_port" type="int" value="$(arg tcp_port)"/>
+		</node>
+		<node name="trajectory_subscriber" pkg="niryo_moveit" type="trajectory_subscriber.py" args="--wait" output="screen"/>
+	</launch>
+   ```
+
+   > Note: To use a port other than 10000, or if you want to listen on a more restrictive ip address than 0.0.0.0 (e.g. for security reasons), you can pass those arguments into the roslaunch command like this:
+
+   ```bash
+   roslaunch niryo_moveit part_2.launch tcp_ip:=127.0.0.1 tcp_port:=10005
    ```
 
    This launch will print various messages to the console, including the set parameters and the nodes launched.

--- a/tutorials/pick_and_place/3_pick_and_place.md
+++ b/tutorials/pick_and_place/3_pick_and_place.md
@@ -170,6 +170,12 @@ def plan_trajectory(move_group, destination_pose, start_joint_angles):
 
     > Note: This may print out various error messages such as `Failed to find 3D sensor plugin`. These messages are safe to ignore as long as the final message to the console is `You can start planning now!`.
 
+	> Note: As with part 2, you can configure this launch file with a custom IP address or port:
+   ```bash
+   roslaunch niryo_moveit part_3.launch tcp_ip:=127.0.0.1 tcp_port:=10005
+   ```
+
+
 1. Return to the Unity Editor and press Play. Press the UI Button to send the joint configurations to ROS, and watch the robot arm pick up and place the cube!
    - The target object and placement positions can be moved around during runtime for different trajectory calculations.
 

--- a/tutorials/pick_and_place/4_pick_and_place.md
+++ b/tutorials/pick_and_place/4_pick_and_place.md
@@ -337,15 +337,18 @@ void Start()
 ## Add niryo_moveit Package
 The Niryo One ROS stack is already installed on the robot and only the `niryo_moveit` package will need to be added.
 
-1. Update the `niryo_moveit/config/params.yml` file's `ROS_IP` parameter to match that of the Niryo One.
-
 1. Copy the `niryo_moveit` package to the `catkin_ws` directory on the Niryo One's catkin workspace at `/home/niryo/catkin_ws` and run the `catkin_make` command.
 
 > Using the SCP command to transfer the `niryo_moveit` package might look something like, `scp -r ~/PATH/TO/niryo_moveit niryo@NIRYO_IP_ADDRESS:/home/niryo/catkin_ws/src`
 
 # Execution
-1. Use the `part_4.launch` file to setup the ROS params and start the `server_endpoint` and `sim_real_pnp` scripts.
+1. Use the `part_4.launch` file to start the `server_endpoint` and `sim_real_pnp` scripts.
 	- `roslaunch niryo_moveit part_4.launch`
+
+	> Note: As with previous parts, you can configure this launch file with a custom IP address or port:
+   ```bash
+   roslaunch niryo_moveit part_4.launch tcp_ip:=127.0.0.1 tcp_port:=10005
+   ```
 
 1. Return to the Unity Editor and press Play. Press the UI Button to send the joint configurations to ROS on the Niryo One, and watch the robot arm move simultaneously in simulation and real life!
 

--- a/tutorials/pick_and_place/ROS/src/niryo_moveit/launch/part_2.launch
+++ b/tutorials/pick_and_place/ROS/src/niryo_moveit/launch/part_2.launch
@@ -1,5 +1,10 @@
 <launch>
-    <rosparam file="$(find niryo_moveit)/config/params.yaml" command="load"/>
-    <node name="server_endpoint" pkg="ros_tcp_endpoint" type="default_server_endpoint.py" args="--wait" output="screen" respawn="true" />
+    <arg name="tcp_ip" default="0.0.0.0"/>
+    <arg name="tcp_port" default="10000"/>
+	
+    <node name="server_endpoint" pkg="ros_tcp_endpoint" type="default_server_endpoint.py" args="--wait" output="screen" respawn="true">
+		<param name="tcp_ip" type="string" value="$(arg tcp_ip)"/>
+        <param name="tcp_port" type="int" value="$(arg tcp_port)"/>
+	</node>
     <node name="trajectory_subscriber" pkg="niryo_moveit" type="trajectory_subscriber.py" args="--wait" output="screen"/>
 </launch>

--- a/tutorials/pick_and_place/ROS/src/niryo_moveit/launch/part_3.launch
+++ b/tutorials/pick_and_place/ROS/src/niryo_moveit/launch/part_3.launch
@@ -1,6 +1,11 @@
 <launch>
-    <rosparam file="$(find niryo_moveit)/config/params.yaml" command="load"/>
-    <node name="server_endpoint" pkg="ros_tcp_endpoint" type="default_server_endpoint.py" args="--wait" output="screen" respawn="true" />
+    <arg name="tcp_ip" default="0.0.0.0"/>
+    <arg name="tcp_port" default="10000"/>
+	
+    <node name="server_endpoint" pkg="ros_tcp_endpoint" type="default_server_endpoint.py" args="--wait" output="screen" respawn="true">
+		<param name="tcp_ip" type="string" value="$(arg tcp_ip)"/>
+        <param name="tcp_port" type="int" value="$(arg tcp_port)"/>
+	</node>
     <node name="mover" pkg="niryo_moveit" type="mover.py" args="--wait" output="screen"/>
     <include file="$(find niryo_moveit)/launch/demo.launch" />
 </launch>

--- a/tutorials/pick_and_place/ROS/src/niryo_moveit/launch/part_4.launch
+++ b/tutorials/pick_and_place/ROS/src/niryo_moveit/launch/part_4.launch
@@ -1,5 +1,10 @@
 <launch>
-    <rosparam file="$(find niryo_moveit)/config/params.yaml" command="load"/>
-    <node name="server_endpoint" pkg="ros_tcp_endpoint" type="default_server_endpoint.py" args="--wait" output="screen" respawn="true" />
+    <arg name="tcp_ip" default="0.0.0.0"/>
+    <arg name="tcp_port" default="10000"/>
+	
+    <node name="server_endpoint" pkg="ros_tcp_endpoint" type="default_server_endpoint.py" args="--wait" output="screen" respawn="true">
+		<param name="tcp_ip" type="string" value="$(arg tcp_ip)"/>
+        <param name="tcp_port" type="int" value="$(arg tcp_port)"/>
+	</node>
     <node name="sim_real_pnp" pkg="niryo_moveit" type="sim_real_pnp.py" args="--wait" output="screen"/>
 </launch>

--- a/tutorials/pick_and_place/docker/set-up-workspace
+++ b/tutorials/pick_and_place/docker/set-up-workspace
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 source /opt/ros/melodic/setup.bash
-echo "ROS_IP: $(hostname -i)" > $ROS_WORKSPACE/src/ros-tcp-endpoint/config/params.yaml
 cd $ROS_WORKSPACE
 catkin_make

--- a/tutorials/ros_unity_integration/ros_docker/set-up-workspace
+++ b/tutorials/ros_unity_integration/ros_docker/set-up-workspace
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 source /opt/ros/$ROS_DISTRO/setup.bash
-echo "ROS_IP: 0.0.0.0" > $ROS_WORKSPACE/src/ros_tcp_endpoint/config/params.yaml
 cd $ROS_WORKSPACE
 catkin_make

--- a/tutorials/ros_unity_integration/setup.md
+++ b/tutorials/ros_unity_integration/setup.md
@@ -24,38 +24,12 @@ Follow these steps to use ROS (melodic or noetic):
 
    ```bash
    source devel/setup.bash
-   roscore
-   ```
-
-   Once ROS Core has started, it will print `started core service [/rosout]` to the terminal window.
-
-3. In your previous terminal, run the following command, replacing the `<your IP address>` with your ROS machine's IP or hostname.
-
-    ```bash
-    rosparam set ROS_IP <your IP address>
-    ```
-
-   - If you're running ROS in a Docker container, you can just use `rosparam set ROS_IP 0.0.0.0`
-   - On Linux you can find out your IP address with the command `hostname -I`
-   - On MacOS you can find out your IP address with `ipconfig getifaddr en0`
-
-6. (Optional) By default, the server_endpoint will listen on port 10000, but this is also controlled by a parameter. If you need to change it, you can run the command `rosparam set ROS_TCP_PORT 10000`, replacing 10000 with the desired port number.
-
-7. Start the server endpoint with the following command:
-
-   ```bash
-    rosrun ros_tcp_endpoint default_server_endpoint.py
+   roslaunch ros_tcp_endpoint endpoint.launch
    ```
 
    Once the server_endpoint has started, it will print something similar to `[INFO] [1603488341.950794]: Starting server on 192.168.50.149:10000`.
 
-> Note, for this tutorial we have illustrated how to do everything manually, but for day-to-day use, we recommend starting the endpoint with a launch file. Replace all the above (including the roscore step) with the following command: `roslaunch ros_tcp_endpoint endpoint.launch`.
-> While using this launch file, your ROS_IP and ROS_TCP_PORT parameters are read from the file src/ros_tcp_endpoint/config/params.yaml. You can edit this file to adjust your settings - for example, this command will set the appropriate IP address for your machine:
-> `echo "ROS_IP: $(hostname -i)" > src/ros-tcp-endpoint/config/params.yaml`
-
-> Read more about rosparam YAML options [here](http://wiki.ros.org/rosparam).
->
-> Read more about the ROS Parameter Server [here](http://wiki.ros.org/Parameter%20Server).
+> Note, By default, the server_endpoint will listen on ip 0.0.0.0 (i.e. allowing all incoming addresses) and port 10000, but these settings are configurable. To override them, you can change the command to `roslaunch ros_tcp_endpoint endpoint.launch tcp_ip:=127.0.0.1 tcp_port:=10000` (obviously replacing 127.0.0.1 with your desired IP and 10000 with your desired port number.)
 
 ## <img src="images/ros2_icon.png" alt="ros2" width="46" height="28"/> ROS2 Environment
 


### PR DESCRIPTION
Bringing tutorials up to date with AIRO-1617, namely the removal of params.yaml, and changing the global ROS_IP and ROS_PORT parameters to local parameters tcp_ip and tcp_port.