### PR TITLE
Support moving the robot

### DIFF
--- a/tutorials/pick_and_place/Scripts/TrajectoryPlanner.cs
+++ b/tutorials/pick_and_place/Scripts/TrajectoryPlanner.cs
@@ -128,7 +128,7 @@ public class TrajectoryPlanner : MonoBehaviour
         // Pick Pose
         request.pick_pose = new PoseMsg
         {
-            position = (m_Target.transform.position + m_PickPoseOffset).To<FLU>(),
+            position = (m_Target.transform.localPosition + m_PickPoseOffset).To<FLU>(),
 
             // The hardcoded x/z angles assure that the gripper is always positioned above the target cube before grasping.
             orientation = Quaternion.Euler(90, m_Target.transform.eulerAngles.y, 0).To<FLU>()
@@ -137,7 +137,7 @@ public class TrajectoryPlanner : MonoBehaviour
         // Place Pose
         request.place_pose = new PoseMsg
         {
-            position = (m_TargetPlacement.transform.position + m_PickPoseOffset).To<FLU>(),
+            position = (m_TargetPlacement.transform.localPosition + m_PickPoseOffset).To<FLU>(),
             orientation = m_PickOrientation.To<FLU>()
         };
 


### PR DESCRIPTION
Use local coordinates for the target and target placement game objects instead of the global ones. These remain constant if you parent the table, robot and markers in order to move as a group. (This supports display on a HoloLens 2 for instance). 

## Proposed change(s)

Describe the changes made in this PR.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment.

### Test Configuration:
- Unity Version: [e.g. Unity 2020.2.0f1]
- Unity machine OS + version: [e.g. Windows 10]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]
- ROS–Unity communication: [e.g. Docker]

I have tested this using Unity 2020.3.26f1 and also deployed to a HoloLens2 with ROS1 noetic running on an Ubuntu VM

## Checklist
- [ ] Ensured this PR is up-to-date with the `dev` branch
- [ ] Created this PR to target the `dev` branch
- [ ] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments
