### PR TITLE
[CI] Use pinned version of mac image

### DIFF
--- a/.yamato/sonar.yml
+++ b/.yamato/sonar.yml
@@ -2,7 +2,7 @@ csharp:
     name: Sonarqube C# Scan
     agent:
         type: Unity::metal::macmini
-        image: package-ci/mac
+        image: package-ci/mac:v1.8.1-822785
         flavor: m1.mac
     variables:
         PROJECT_PATH: tutorials/pick_and_place/PickAndPlaceProject
@@ -36,7 +36,7 @@ standard:
     name: Sonarqube Standard Scan
     agent:
         type: Unity::metal::macmini
-        image: package-ci/mac
+        image: package-ci/mac:v1.8.1-822785
         flavor: m1.mac
     variables:
         SONARQUBE_PROJECT_KEY: ai-robotics-hub-standard


### PR DESCRIPTION
## Proposed change(s)

We are going to stop allowing people to target a Bokken image without specifying a tag.
Only a handful of people are using it, and it gets in the way of using sourcegraph insights to estimate usage.
Currently, no tag equals using the stable version of the image.
I used a pinned version instead of stable because that tag is also going to disappear and I want to prevent you from having to do another maintenance in a few months.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

JIRA Ticket https://jira.unity3d.com/browse/DSBKN-1034
Image version in the Bokken image catalogue http://images.bokken.cloud:8000/#/image/package-ci/mac/673349491555729414

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [x] Other (please describe) CI fix

## Testing and Verification

Run affected CI pipeline on Yamato.

### Test Configuration: Not applicable (CI environment)
- Unity Version: [e.g. Unity 2020.2.0f1]
- Unity machine OS + version: [e.g. Windows 10]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]
- ROS–Unity communication: [e.g. Docker]

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works --> Not applicable
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md#unreleased) --> Not applicable
- [ ] Updated the documentation as appropriate --> Not applicable

## Other comments
