### PR TITLE
Update 0_ros_setup.md

### DIFF
--- a/tutorials/pick_and_place/0_ros_setup.md
+++ b/tutorials/pick_and_place/0_ros_setup.md
@@ -31,7 +31,7 @@ git clone --recurse-submodules https://github.com/Unity-Technologies/Unity-Robot
     ```bash
     cd /PATH/TO/Unity-Robotics-Hub/tutorials/pick_and_place &&
     git submodule update --init --recursive &&
-    docker build -t unity-robotics:pick-and-place -f docker/Dockerfile .
+    sudo docker build -t unity-robotics:pick-and-place -f docker/Dockerfile .
     ```
 
     > Note: The provided Dockerfile uses the [ROS Melodic base Image](https://hub.docker.com/_/ros/). Building the image will install the necessary packages, copy the [provided ROS packages and submodules](ROS/) to the container, and build the catkin workspace.
@@ -39,7 +39,7 @@ git clone --recurse-submodules https://github.com/Unity-Technologies/Unity-Robot
 1. Start the newly built Docker container:
 
     ```docker
-    docker run -it --rm -p 10000:10000 unity-robotics:pick-and-place /bin/bash
+    sudo docker run -it --rm -p 10000:10000 unity-robotics:pick-and-place /bin/bash
     ```
 
     When this is complete, it will print: `Successfully tagged unity-robotics:pick-and-place`. This console should open into a bash shell at the ROS workspace root, e.g. `root@8d88ed579657:/catkin_ws#`.


### PR DESCRIPTION
## Proposed change(s)

docker build and docker run require root privileges - I have added the sudo command to these in order to be consistent with the rest of the setup instructions.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ x] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Ran commands as normal user without privileges, they fail with permission denied. They need to be added to the docker commands.

### Test Configuration:
- Unity Version: [e.g. Unity 2020.2.0f1]
- Unity machine OS + version: [Ubuntu 22.04]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]
- ROS–Unity communication: [e.g. Docker]

## Checklist
- [ ] Ensured this PR is up-to-date with the `dev` branch
- [ ] Created this PR to target the `dev` branch
- [ ] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md#unreleased)
- [x ] Updated the documentation as appropriate

## Other comments
